### PR TITLE
feat: Concurrency uplift

### DIFF
--- a/packages/sip/bin/sip.dart
+++ b/packages/sip/bin/sip.dart
@@ -12,6 +12,11 @@ import 'package:sip_cli/sip_runner.dart';
 import 'package:sip_cli/utils/key_press_listener.dart';
 
 void main(List<String> arguments) async {
+  ProcessSignal.sigint.watch().listen(
+        (signal) => exit(1),
+        cancelOnError: true,
+      );
+
   final args = List<String>.from(arguments);
 
   var loud = false;

--- a/packages/sip/bin/sip.dart
+++ b/packages/sip/bin/sip.dart
@@ -9,6 +9,7 @@ import 'package:sip_cli/domain/bindings_impl.dart';
 import 'package:sip_cli/domain/domain.dart';
 import 'package:sip_cli/domain/variables.dart';
 import 'package:sip_cli/sip_runner.dart';
+import 'package:sip_cli/utils/key_press_listener.dart';
 
 void main(List<String> arguments) async {
   final args = List<String>.from(arguments);
@@ -35,11 +36,23 @@ void main(List<String> arguments) async {
   const scriptsYaml = ScriptsYamlImpl(fs: fs);
   const pubspecYaml = PubspecYamlImpl(fs: fs);
   const cwd = CWDImpl(fs: fs);
+  final bindings = BindingsImpl(
+    logger: logger,
+  );
+
+  final runOneScript = RunOneScript(
+    bindings: bindings,
+    logger: logger,
+  );
+
+  final runManyScripts = RunManyScripts(
+    bindings: bindings,
+    logger: logger,
+    runOneScript: runOneScript,
+  );
 
   final exitCode = await SipRunner(
-    bindings: BindingsImpl(
-      logger: logger,
-    ),
+    bindings: bindings,
     scriptsYaml: scriptsYaml,
     findFile: const FindFile(fs: fs),
     pubspecLock: const PubspecLockImpl(fs: fs),
@@ -53,6 +66,9 @@ void main(List<String> arguments) async {
     logger: logger,
     cwd: cwd,
     pubUpdater: PubUpdater(),
+    runOneScript: runOneScript,
+    runManyScripts: runManyScripts,
+    keyPressListener: KeyPressListener(logger: logger),
   ).run(args);
 
   logger.detail('$args Finishing with: $exitCode');

--- a/packages/sip/lib/commands/pub_command.dart
+++ b/packages/sip/lib/commands/pub_command.dart
@@ -11,6 +11,8 @@ import 'package:sip_cli/domain/constrain_pubspec_versions.dart';
 import 'package:sip_cli/domain/find_file.dart';
 import 'package:sip_cli/domain/pubspec_lock.dart';
 import 'package:sip_cli/domain/pubspec_yaml.dart';
+import 'package:sip_cli/domain/run_many_scripts.dart';
+import 'package:sip_cli/domain/run_one_script.dart';
 import 'package:sip_cli/domain/scripts_yaml.dart';
 import 'package:sip_cli/utils/exit_code.dart';
 
@@ -24,6 +26,8 @@ class PubCommand extends Command<ExitCode> {
     required Logger logger,
     required Bindings bindings,
     required ScriptsYaml scriptsYaml,
+    required RunManyScripts runManyScripts,
+    required RunOneScript runOneScript,
   }) {
     addSubcommand(
       PubGetCommand(
@@ -34,6 +38,8 @@ class PubCommand extends Command<ExitCode> {
         logger: logger,
         bindings: bindings,
         scriptsYaml: scriptsYaml,
+        runManyScripts: runManyScripts,
+        runOneScript: runOneScript,
       ),
     );
     addSubcommand(
@@ -45,6 +51,8 @@ class PubCommand extends Command<ExitCode> {
         logger: logger,
         bindings: bindings,
         scriptsYaml: scriptsYaml,
+        runManyScripts: runManyScripts,
+        runOneScript: runOneScript,
       ),
     );
     addSubcommand(
@@ -56,6 +64,8 @@ class PubCommand extends Command<ExitCode> {
         logger: logger,
         bindings: bindings,
         scriptsYaml: scriptsYaml,
+        runManyScripts: runManyScripts,
+        runOneScript: runOneScript,
       ),
     );
     addSubcommand(
@@ -67,6 +77,8 @@ class PubCommand extends Command<ExitCode> {
         logger: logger,
         bindings: bindings,
         scriptsYaml: scriptsYaml,
+        runManyScripts: runManyScripts,
+        runOneScript: runOneScript,
       ),
     );
     addSubcommand(

--- a/packages/sip/lib/commands/pub_deps_command.dart
+++ b/packages/sip/lib/commands/pub_deps_command.dart
@@ -14,6 +14,8 @@ class PubDepsCommand extends APubCommand {
     required super.bindings,
     required super.findFile,
     required super.scriptsYaml,
+    required super.runManyScripts,
+    required super.runOneScript,
   }) : super(runConcurrently: false) {
     argParser.addOption(
       'style',

--- a/packages/sip/lib/commands/pub_downgrade_command.dart
+++ b/packages/sip/lib/commands/pub_downgrade_command.dart
@@ -14,6 +14,8 @@ class PubDowngradeCommand extends APubCommand {
     required super.bindings,
     required super.findFile,
     required super.scriptsYaml,
+    required super.runManyScripts,
+    required super.runOneScript,
   }) {
     argParser.addFlag(
       'offline',

--- a/packages/sip/lib/commands/pub_get_command.dart
+++ b/packages/sip/lib/commands/pub_get_command.dart
@@ -14,6 +14,8 @@ class PubGetCommand extends APubCommand {
     required super.bindings,
     required super.findFile,
     required super.scriptsYaml,
+    required super.runManyScripts,
+    required super.runOneScript,
   }) {
     argParser
       ..addFlag(

--- a/packages/sip/lib/commands/pub_upgrade_command.dart
+++ b/packages/sip/lib/commands/pub_upgrade_command.dart
@@ -17,6 +17,8 @@ class PubUpgradeCommand extends APubCommand {
     required super.fs,
     required super.logger,
     required super.scriptsYaml,
+    required super.runManyScripts,
+    required super.runOneScript,
   }) {
     argParser.addFlag(
       'offline',

--- a/packages/sip/lib/commands/script_run_command.dart
+++ b/packages/sip/lib/commands/script_run_command.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: cascade_invocations
 
+import 'dart:async';
+
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:mason_logger/mason_logger.dart' hide ExitCode;
@@ -18,30 +20,6 @@ import 'package:sip_cli/utils/exit_code_extensions.dart';
 import 'package:sip_cli/utils/run_script_helper.dart';
 import 'package:sip_cli/utils/stopwatch_extensions.dart';
 import 'package:sip_cli/utils/working_directory.dart';
-
-// TODO(mrgnhnt): Handle when the user presses Ctrl+C
-/*
-var attemptsToKill = 0;
-    final stream = Platform.isWindows
-        ? ProcessSignal.sigint.watch()
-        : StreamGroup.merge(
-            [
-              ProcessSignal.sigterm.watch(),
-              ProcessSignal.sigint.watch(),
-            ],
-          );
-
-    _killSubscription ??= stream.listen((event) {
-      logger.detail('Received SIGINT');
-      if (attemptsToKill > 0) {
-        exit(1);
-      } else if (attemptsToKill == 0) {
-        stop().ignore();
-      }
-
-      attemptsToKill++;
-    });
-*/
 
 /// The command to run a script
 class ScriptRunCommand extends Command<ExitCode>
@@ -150,7 +128,7 @@ class ScriptRunCommand extends Command<ExitCode>
 
     final bail = result.bail ^ (argResults['bail'] as bool? ?? false);
 
-    Future<ExitCode> runCommands() => _run(
+    Future<ExitCode> runCommands() => _runCommands(
           argResults: argResults,
           bail: bail,
           concurrent: concurrent,
@@ -182,7 +160,7 @@ class ScriptRunCommand extends Command<ExitCode>
     return runCommands();
   }
 
-  Future<ExitCode> _run({
+  Future<ExitCode> _runCommands({
     required ArgResults argResults,
     required bool bail,
     required bool concurrent,

--- a/packages/sip/lib/commands/test_clean_command.dart
+++ b/packages/sip/lib/commands/test_clean_command.dart
@@ -6,6 +6,8 @@ import 'package:sip_cli/domain/bindings.dart';
 import 'package:sip_cli/domain/find_file.dart';
 import 'package:sip_cli/domain/pubspec_lock.dart';
 import 'package:sip_cli/domain/pubspec_yaml.dart';
+import 'package:sip_cli/domain/run_many_scripts.dart';
+import 'package:sip_cli/domain/run_one_script.dart';
 import 'package:sip_cli/domain/scripts_yaml.dart';
 import 'package:sip_cli/utils/exit_code.dart';
 
@@ -18,6 +20,8 @@ class TestCleanCommand extends Command<ExitCode> with TesterMixin {
     required this.pubspecLock,
     required this.pubspecYaml,
     required this.scriptsYaml,
+    required this.runManyScripts,
+    required this.runOneScript,
   });
 
   @override
@@ -46,6 +50,12 @@ class TestCleanCommand extends Command<ExitCode> with TesterMixin {
 
   @override
   final ScriptsYaml scriptsYaml;
+
+  @override
+  final RunManyScripts runManyScripts;
+
+  @override
+  final RunOneScript runOneScript;
 
   @override
   Future<ExitCode> run() async {

--- a/packages/sip/lib/commands/test_command/test_command.dart
+++ b/packages/sip/lib/commands/test_command/test_command.dart
@@ -10,6 +10,8 @@ import 'package:sip_cli/domain/bindings.dart';
 import 'package:sip_cli/domain/find_file.dart';
 import 'package:sip_cli/domain/pubspec_lock.dart';
 import 'package:sip_cli/domain/pubspec_yaml.dart';
+import 'package:sip_cli/domain/run_many_scripts.dart';
+import 'package:sip_cli/domain/run_one_script.dart';
 import 'package:sip_cli/domain/scripts_yaml.dart';
 import 'package:sip_cli/utils/exit_code.dart';
 import 'package:sip_cli/utils/key_press_listener.dart';
@@ -24,6 +26,8 @@ class TestCommand extends Command<ExitCode> {
     required FindFile findFile,
     required KeyPressListener keyPressListener,
     required ScriptsYaml scriptsYaml,
+    required RunManyScripts runManyScripts,
+    required RunOneScript runOneScript,
   }) {
     addSubcommand(
       TestRunCommand(
@@ -34,6 +38,8 @@ class TestCommand extends Command<ExitCode> {
         pubspecLock: pubspecLock,
         pubspecYaml: pubspecYaml,
         scriptsYaml: scriptsYaml,
+        runManyScripts: runManyScripts,
+        runOneScript: runOneScript,
       ),
     );
 
@@ -46,6 +52,8 @@ class TestCommand extends Command<ExitCode> {
         pubspecLock: pubspecLock,
         pubspecYaml: pubspecYaml,
         scriptsYaml: scriptsYaml,
+        runManyScripts: runManyScripts,
+        runOneScript: runOneScript,
       ),
     );
 
@@ -59,6 +67,8 @@ class TestCommand extends Command<ExitCode> {
         pubspecYaml: pubspecYaml,
         keyPressListener: keyPressListener,
         scriptsYaml: scriptsYaml,
+        runManyScripts: runManyScripts,
+        runOneScript: runOneScript,
       ),
     );
   }

--- a/packages/sip/lib/commands/test_command/tester_mixin.dart
+++ b/packages/sip/lib/commands/test_command/tester_mixin.dart
@@ -40,6 +40,8 @@ abstract mixin class TesterMixin {
   FileSystem get fs;
   Bindings get bindings;
   ScriptsYaml get scriptsYaml;
+  RunManyScripts get runManyScripts;
+  RunOneScript get runOneScript;
 
   ({
     List<String> both,
@@ -350,13 +352,9 @@ abstract mixin class TesterMixin {
         logger.detail('Script: ${darkGray.wrap(command.command)}');
       }
 
-      final runMany = RunManyScripts(
-        commands: commandsToRun,
-        bindings: bindings,
-        logger: logger,
-      );
-
-      final exitCodes = await runMany.run(
+      final exitCodes = await runManyScripts.run(
+        commands: commandsToRun.toList(),
+        sequentially: false,
         label: 'Running tests ',
         bail: bail,
       );
@@ -370,19 +368,16 @@ abstract mixin class TesterMixin {
 
     for (final command in commandsToRun) {
       logger.detail(command.command);
-      final scriptRunner = RunOneScript(
-        command: command,
-        bindings: bindings,
-        logger: logger,
-        showOutput: true,
-        filter: command.filterOutput,
-      );
 
       final stopwatch = Stopwatch()..start();
 
       logger.info(darkGray.wrap(command.label));
 
-      final result = await scriptRunner.run();
+      final result = await runOneScript.run(
+        command: command,
+        showOutput: true,
+        filter: command.filterOutput,
+      );
 
       final time = (stopwatch..stop()).format();
 

--- a/packages/sip/lib/commands/test_run_command.dart
+++ b/packages/sip/lib/commands/test_run_command.dart
@@ -11,6 +11,8 @@ import 'package:sip_cli/domain/command_to_run.dart';
 import 'package:sip_cli/domain/find_file.dart';
 import 'package:sip_cli/domain/pubspec_lock.dart';
 import 'package:sip_cli/domain/pubspec_yaml.dart';
+import 'package:sip_cli/domain/run_many_scripts.dart';
+import 'package:sip_cli/domain/run_one_script.dart';
 import 'package:sip_cli/domain/scripts_yaml.dart';
 import 'package:sip_cli/utils/determine_flutter_or_dart.dart';
 import 'package:sip_cli/utils/exit_code.dart';
@@ -24,6 +26,8 @@ class TestRunCommand extends Command<ExitCode> with TesterMixin {
     required this.fs,
     required this.logger,
     required this.scriptsYaml,
+    required this.runManyScripts,
+    required this.runOneScript,
   }) : argParser = ArgParser(usageLineLength: 120) {
     addTestFlags(this);
 
@@ -112,6 +116,12 @@ class TestRunCommand extends Command<ExitCode> with TesterMixin {
 
   @override
   final ScriptsYaml scriptsYaml;
+
+  @override
+  final RunManyScripts runManyScripts;
+
+  @override
+  final RunOneScript runOneScript;
 
   @override
   String get description => 'Run flutter or dart tests';

--- a/packages/sip/lib/commands/test_watch_command.dart
+++ b/packages/sip/lib/commands/test_watch_command.dart
@@ -11,6 +11,8 @@ import 'package:sip_cli/domain/find_file.dart';
 import 'package:sip_cli/domain/package_to_test.dart';
 import 'package:sip_cli/domain/pubspec_lock.dart';
 import 'package:sip_cli/domain/pubspec_yaml.dart';
+import 'package:sip_cli/domain/run_many_scripts.dart';
+import 'package:sip_cli/domain/run_one_script.dart';
 import 'package:sip_cli/domain/scripts_yaml.dart';
 import 'package:sip_cli/domain/test_scope.dart';
 import 'package:sip_cli/utils/exit_code.dart';
@@ -27,6 +29,8 @@ class TestWatchCommand extends Command<ExitCode> with TesterMixin {
     required this.pubspecYaml,
     required this.keyPressListener,
     required this.scriptsYaml,
+    required this.runManyScripts,
+    required this.runOneScript,
   }) : argParser = ArgParser(usageLineLength: 120) {
     addTestFlags(this);
 
@@ -107,6 +111,12 @@ class TestWatchCommand extends Command<ExitCode> with TesterMixin {
   final ScriptsYaml scriptsYaml;
 
   final KeyPressListener keyPressListener;
+
+  @override
+  final RunManyScripts runManyScripts;
+
+  @override
+  final RunOneScript runOneScript;
 
   void writeWaitingMessage(TestScope scope, {required bool runConcurrently}) {
     var testScope = darkGray.wrap('Test Scope: ')!;

--- a/packages/sip/lib/domain/command_to_run.dart
+++ b/packages/sip/lib/domain/command_to_run.dart
@@ -9,12 +9,11 @@ class CommandToRun extends Equatable {
     required this.command,
     required this.workingDirectory,
     required this.keys,
-    this.group = 0,
     this.bail = false,
     this.envConfig,
     this.runConcurrently = false,
     this.filterOutput,
-    this.runPreviousFirst = false,
+    this.needsRunBeforeNext = false,
     String? label,
   }) : label = label ?? command;
 
@@ -32,17 +31,7 @@ class CommandToRun extends Equatable {
   /// This is useful to "break" up the commands into smaller concurrent groups
   ///
   /// This does not apply if [runConcurrently] is false
-  final bool runPreviousFirst;
-
-  /// The group number for this command.
-  ///
-  /// Pre-resolved scripts can make reference to other scripts which contain
-  /// arrays of commands. The [group] number is used to identify where the
-  /// post-resolved script derived from.
-  ///
-  /// Grouping can be used to run concurrent groups of commands. To avoid
-  /// unintentionally running all commands concurrently
-  final int group;
+  final bool needsRunBeforeNext;
 
   @override
   List<Object?> get props => _$props;

--- a/packages/sip/lib/domain/command_to_run.dart
+++ b/packages/sip/lib/domain/command_to_run.dart
@@ -9,10 +9,12 @@ class CommandToRun extends Equatable {
     required this.command,
     required this.workingDirectory,
     required this.keys,
+    this.group = 0,
     this.bail = false,
     this.envConfig,
     this.runConcurrently = false,
     this.filterOutput,
+    this.runPreviousFirst = false,
     String? label,
   }) : label = label ?? command;
 
@@ -24,6 +26,23 @@ class CommandToRun extends Equatable {
   final EnvConfig? envConfig;
   final FilterType? filterOutput;
   final bool bail;
+
+  /// Whether to run the previous command first.
+  ///
+  /// This is useful to "break" up the commands into smaller concurrent groups
+  ///
+  /// This does not apply if [runConcurrently] is false
+  final bool runPreviousFirst;
+
+  /// The group number for this command.
+  ///
+  /// Pre-resolved scripts can make reference to other scripts which contain
+  /// arrays of commands. The [group] number is used to identify where the
+  /// post-resolved script derived from.
+  ///
+  /// Grouping can be used to run concurrent groups of commands. To avoid
+  /// unintentionally running all commands concurrently
+  final int group;
 
   @override
   List<Object?> get props => _$props;

--- a/packages/sip/lib/domain/command_to_run.g.dart
+++ b/packages/sip/lib/domain/command_to_run.g.dart
@@ -14,5 +14,8 @@ extension _$CommandToRunAutoequal on CommandToRun {
         runConcurrently,
         keys,
         envConfig,
+        filterOutput,
+        bail,
+        needsRunBeforeNext,
       ];
 }

--- a/packages/sip/lib/domain/resolve_script.dart
+++ b/packages/sip/lib/domain/resolve_script.dart
@@ -1,0 +1,64 @@
+import 'package:sip_cli/domain/env_config.dart';
+import 'package:sip_cli/domain/script.dart';
+
+class ResolveScript {
+  ResolveScript({
+    required this.resolvedScripts,
+    required this.envConfig,
+    required this.script,
+    required this.needsRunBeforeNext,
+  }) : originalCommand = null;
+
+  ResolveScript._({
+    required this.resolvedScripts,
+    required this.envConfig,
+    required this.script,
+    required this.originalCommand,
+    required this.needsRunBeforeNext,
+    required String? replacedCommand,
+  }) : _replacedCommand = replacedCommand;
+
+  ResolveScript.command({
+    required String command,
+    required this.envConfig,
+    required this.script,
+    required this.needsRunBeforeNext,
+  })  : resolvedScripts = const [],
+        originalCommand = command;
+
+  final Script script;
+  final String? originalCommand;
+  final Iterable<ResolveScript> resolvedScripts;
+  final EnvConfig? envConfig;
+  final bool needsRunBeforeNext;
+
+  String? _replacedCommand;
+
+  void replaceCommandPart(String part, String replacement) {
+    _replacedCommand ??= command;
+    _replacedCommand = _replacedCommand?.replaceAll(part, replacement);
+  }
+
+  ResolveScript copy({
+    EnvConfig? envConfig,
+    bool? needsRunBeforeNext,
+  }) {
+    return ResolveScript._(
+      resolvedScripts: resolvedScripts,
+      envConfig: envConfig ?? this.envConfig,
+      script: script,
+      originalCommand: originalCommand,
+      replacedCommand: _replacedCommand,
+      needsRunBeforeNext: needsRunBeforeNext ?? this.needsRunBeforeNext,
+    );
+  }
+
+  Iterable<ResolveScript> get flatten => {
+        if (command != null)
+          this
+        else if (resolvedScripts.isNotEmpty)
+          ...resolvedScripts.expand((e) => e.flatten),
+      };
+
+  String? get command => _replacedCommand ?? originalCommand;
+}

--- a/packages/sip/lib/domain/run_one_script.dart
+++ b/packages/sip/lib/domain/run_one_script.dart
@@ -9,24 +9,20 @@ import 'package:sip_cli/domain/filter_type.dart';
 
 class RunOneScript {
   const RunOneScript({
-    required this.command,
     required this.bindings,
     required this.logger,
-    required this.showOutput,
-    this.retryAfter,
-    this.maxAttempts = 3,
-    this.filter,
   });
 
-  final CommandToRun command;
   final Bindings bindings;
-  final bool showOutput;
   final Logger logger;
-  final Duration? retryAfter;
-  final int maxAttempts;
-  final FilterType? filter;
 
-  Future<CommandResult> run() async {
+  Future<CommandResult> run({
+    required CommandToRun command,
+    required bool showOutput,
+    Duration? retryAfter,
+    int maxAttempts = 3,
+    FilterType? filter,
+  }) async {
     var cmd = command.command;
 
     logger.detail('Env files: ${command.envConfig?.files}');
@@ -79,7 +75,6 @@ $cmd
     );
 
     CommandResult codeResult;
-    final retryAfter = this.retryAfter;
     if (retryAfter == null) {
       logger.detail('Not retrying');
       final result = await runScript;

--- a/packages/sip/lib/domain/variables.dart
+++ b/packages/sip/lib/domain/variables.dart
@@ -4,6 +4,7 @@ import 'package:sip_cli/domain/cwd.dart';
 import 'package:sip_cli/domain/env_config.dart';
 import 'package:sip_cli/domain/optional_flags.dart';
 import 'package:sip_cli/domain/pubspec_yaml.dart';
+import 'package:sip_cli/domain/resolve_script.dart';
 import 'package:sip_cli/domain/script.dart';
 import 'package:sip_cli/domain/scripts_config.dart';
 import 'package:sip_cli/domain/scripts_yaml.dart';
@@ -355,68 +356,6 @@ class Variables with WorkingDirectory {
     yield* commands;
     yield last.copy(needsRunBeforeNext: true);
   }
-}
-
-class ResolveScript {
-  ResolveScript({
-    required this.resolvedScripts,
-    required this.envConfig,
-    required this.script,
-    required this.needsRunBeforeNext,
-  }) : originalCommand = null;
-
-  ResolveScript._({
-    required this.resolvedScripts,
-    required this.envConfig,
-    required this.script,
-    required this.originalCommand,
-    required this.needsRunBeforeNext,
-    required String? replacedCommand,
-  }) : _replacedCommand = replacedCommand;
-
-  ResolveScript.command({
-    required String command,
-    required this.envConfig,
-    required this.script,
-    required this.needsRunBeforeNext,
-  })  : resolvedScripts = const [],
-        originalCommand = command;
-
-  final Script script;
-  final String? originalCommand;
-  final Iterable<ResolveScript> resolvedScripts;
-  final EnvConfig? envConfig;
-  final bool needsRunBeforeNext;
-
-  String? _replacedCommand;
-
-  void replaceCommandPart(String part, String replacement) {
-    _replacedCommand ??= command;
-    _replacedCommand = _replacedCommand?.replaceAll(part, replacement);
-  }
-
-  ResolveScript copy({
-    EnvConfig? envConfig,
-    bool? needsRunBeforeNext,
-  }) {
-    return ResolveScript._(
-      resolvedScripts: resolvedScripts,
-      envConfig: envConfig ?? this.envConfig,
-      script: script,
-      originalCommand: originalCommand,
-      replacedCommand: _replacedCommand,
-      needsRunBeforeNext: needsRunBeforeNext ?? this.needsRunBeforeNext,
-    );
-  }
-
-  Iterable<ResolveScript> get flatten => {
-        if (command != null)
-          this
-        else if (resolvedScripts.isNotEmpty)
-          ...resolvedScripts.expand((e) => e.flatten),
-      };
-
-  String? get command => _replacedCommand ?? originalCommand;
 }
 
 extension _ScriptX on Script {

--- a/packages/sip/lib/sip_runner.dart
+++ b/packages/sip/lib/sip_runner.dart
@@ -35,6 +35,9 @@ class SipRunner extends CommandRunner<ExitCode> {
     required FileSystem fs,
     required CWD cwd,
     required PubUpdater pubUpdater,
+    required RunOneScript runOneScript,
+    required RunManyScripts runManyScripts,
+    required KeyPressListener keyPressListener,
     required this.logger,
   }) : super(
           'sip',
@@ -71,6 +74,8 @@ class SipRunner extends CommandRunner<ExitCode> {
         bindings: bindings,
         logger: logger,
         cwd: cwd,
+        runManyScripts: runManyScripts,
+        runOneScript: runOneScript,
       ),
     );
     addCommand(
@@ -82,6 +87,8 @@ class SipRunner extends CommandRunner<ExitCode> {
         logger: logger,
         bindings: bindings,
         scriptsYaml: scriptsYaml,
+        runManyScripts: runManyScripts,
+        runOneScript: runOneScript,
       ),
     );
     addCommand(
@@ -93,6 +100,8 @@ class SipRunner extends CommandRunner<ExitCode> {
         logger: logger,
         cwd: cwd,
         scriptsYaml: scriptsYaml,
+        runManyScripts: runManyScripts,
+        runOneScript: runOneScript,
       ),
     );
     addCommand(
@@ -115,8 +124,10 @@ class SipRunner extends CommandRunner<ExitCode> {
         bindings: bindings,
         fs: fs,
         logger: logger,
-        keyPressListener: KeyPressListener(logger: logger),
+        keyPressListener: keyPressListener,
         scriptsYaml: scriptsYaml,
+        runManyScripts: runManyScripts,
+        runOneScript: runOneScript,
       ),
     );
   }

--- a/packages/sip/lib/utils/run_script_helper.dart
+++ b/packages/sip/lib/utils/run_script_helper.dart
@@ -7,6 +7,7 @@ import 'package:sip_cli/domain/command_to_run.dart';
 import 'package:sip_cli/domain/cwd.dart';
 import 'package:sip_cli/domain/env_config.dart';
 import 'package:sip_cli/domain/optional_flags.dart';
+import 'package:sip_cli/domain/resolve_script.dart';
 import 'package:sip_cli/domain/script.dart';
 import 'package:sip_cli/domain/scripts_config.dart';
 import 'package:sip_cli/domain/scripts_yaml.dart';

--- a/packages/sip/lib/utils/run_script_helper.dart
+++ b/packages/sip/lib/utils/run_script_helper.dart
@@ -138,6 +138,7 @@ $ sip format ui
       script,
       scriptConfig,
       flags: optionalFlags(keys),
+      scriptGroup: null,
     );
 
     for (final resolved in resolvedScripts) {
@@ -156,9 +157,9 @@ $ sip format ui
 
     final ResolveScript(:resolvedScripts, :envConfig) = resolveScript;
 
-    for (var i = 0; i < resolvedScripts.length; i++) {
-      final resolved = resolvedScripts.elementAt(i);
+    for (final resolved in resolvedScripts) {
       var runConcurrently = false;
+      var waitForPrevious = true;
 
       var command = switch (resolved.command) {
         final String command => command,
@@ -171,18 +172,24 @@ $ sip format ui
         );
 
         runConcurrently = true;
+        var count = 0;
         while (command.startsWith(Identifiers.concurrent)) {
+          count++;
           command = command.substring(Identifiers.concurrent.length);
         }
+
+        waitForPrevious = count == 1;
       }
 
       yield CommandToRun(
         command: command.trim(),
         label: command.trim(),
+        group: resolved.group,
         runConcurrently: runConcurrently,
         workingDirectory: directory,
         keys: resolved.script.keys,
         envConfig: resolved.envConfig,
+        runPreviousFirst: waitForPrevious,
       );
     }
   }

--- a/packages/sip/lib/utils/run_script_helper.dart
+++ b/packages/sip/lib/utils/run_script_helper.dart
@@ -138,7 +138,6 @@ $ sip format ui
       script,
       scriptConfig,
       flags: optionalFlags(keys),
-      scriptGroup: null,
     );
 
     for (final resolved in resolvedScripts) {
@@ -159,7 +158,6 @@ $ sip format ui
 
     for (final resolved in resolvedScripts) {
       var runConcurrently = false;
-      var waitForPrevious = true;
 
       var command = switch (resolved.command) {
         final String command => command,
@@ -172,24 +170,19 @@ $ sip format ui
         );
 
         runConcurrently = true;
-        var count = 0;
         while (command.startsWith(Identifiers.concurrent)) {
-          count++;
           command = command.substring(Identifiers.concurrent.length);
         }
-
-        waitForPrevious = count == 1;
       }
 
       yield CommandToRun(
         command: command.trim(),
         label: command.trim(),
-        group: resolved.group,
         runConcurrently: runConcurrently,
         workingDirectory: directory,
         keys: resolved.script.keys,
         envConfig: resolved.envConfig,
-        runPreviousFirst: waitForPrevious,
+        needsRunBeforeNext: resolved.needsRunBeforeNext,
       );
     }
   }
@@ -217,7 +210,7 @@ $ sip format ui
 
       assert(resolveScript != null, 'commands should not be null');
       yield CommandsToRunResult(
-        commands: _commandsToRun(result),
+        commands: _commandsToRun(result).toList(),
         bail: bail,
         combinedEnvConfig: resolveScript?.envConfig,
       );
@@ -227,7 +220,7 @@ $ sip format ui
 
 class CommandsToRunResult {
   const CommandsToRunResult({
-    required Iterable<CommandToRun> this.commands,
+    required List<CommandToRun> this.commands,
     required this.bail,
     required this.combinedEnvConfig,
   }) : exitCode = null;
@@ -237,7 +230,7 @@ class CommandsToRunResult {
         combinedEnvConfig = null;
 
   final ExitCode? exitCode;
-  final Iterable<CommandToRun>? commands;
+  final List<CommandToRun>? commands;
   final EnvConfig? combinedEnvConfig;
   final bool bail;
 }

--- a/packages/sip/test/e2e/run/concurrency_groups/concurrency_groups_test.dart
+++ b/packages/sip/test/e2e/run/concurrency_groups/concurrency_groups_test.dart
@@ -528,6 +528,65 @@ void main() {
 
       expect(results, expected);
     });
+
+    test('should combine all groups when leading with concurrency', () async {
+      final command = setupScripts();
+
+      await command.run(['everything_concurrent']);
+
+      final expected = [
+        [
+          ...[
+            'wait 1',
+            'wait 2',
+            'wait 3',
+            'wait 4',
+            'wait 5',
+            'echo 6',
+            'wait 1; echo 1',
+            'wait 1; echo 2',
+            'wait 1; echo 3',
+          ].map(
+            (e) => CommandToRun(
+              command: e,
+              label: e,
+              workingDirectory: '/packages/sip',
+              keys: const ['everything_concurrent'],
+              needsRunBeforeNext: false,
+              bail: false,
+              runConcurrently: true,
+            ),
+          ),
+        ]
+      ];
+
+      final results = <List<CommandToRun>>[];
+
+      verify(
+        () => runManyScripts.run(
+          commands: any(
+            named: 'commands',
+            that: isA<List<CommandToRun>>().having(
+              (items) {
+                return items;
+              },
+              'has correct scripts',
+              (Object? items) {
+                results.add(items! as List<CommandToRun>);
+                return true;
+              },
+            ),
+          ),
+          sequentially: true,
+          bail: false,
+          label: any(named: 'label'),
+          maxAttempts: any(named: 'maxAttempts'),
+          retryAfter: any(named: 'retryAfter'),
+        ),
+      ).called(1);
+
+      expect(results, expected);
+    });
   });
 }
 

--- a/packages/sip/test/e2e/run/concurrency_groups/concurrency_groups_test.dart
+++ b/packages/sip/test/e2e/run/concurrency_groups/concurrency_groups_test.dart
@@ -448,7 +448,86 @@ void main() {
       }
     });
 
-    test('should combine groups when leading with concurrency', () async {});
+    test('should combine groups when leading with concurrency', () async {
+      final command = setupScripts();
+
+      await command.run(['combined_concurrent']);
+
+      final expected = [
+        [
+          ...[
+            'wait 1',
+            'wait 2',
+          ].map(
+            (e) => CommandToRun(
+              command: e,
+              label: e,
+              workingDirectory: '/packages/sip',
+              keys: const ['combined_concurrent'],
+              needsRunBeforeNext: false,
+              bail: false,
+              runConcurrently: true,
+            ),
+          ),
+          const CommandToRun(
+            command: 'wait 3',
+            label: 'wait 3',
+            workingDirectory: '/packages/sip',
+            keys: ['combined_concurrent'],
+            needsRunBeforeNext: true,
+            bail: false,
+            runConcurrently: true,
+          ),
+        ],
+        [
+          ...[
+            'wait 4',
+            'wait 5',
+            'echo 6',
+            'wait 1; echo 1',
+            'wait 1; echo 2',
+            'wait 1; echo 3',
+          ].map(
+            (e) => CommandToRun(
+              command: e,
+              label: e,
+              workingDirectory: '/packages/sip',
+              keys: const ['combined_concurrent'],
+              needsRunBeforeNext: false,
+              bail: false,
+              runConcurrently: true,
+            ),
+          ),
+        ],
+      ];
+
+      final results = <List<CommandToRun>>[];
+
+      verify(
+        () => runManyScripts.run(
+          commands: any(
+            named: 'commands',
+            that: isA<List<CommandToRun>>().having(
+              (items) {
+                return items;
+              },
+              'has correct scripts',
+              (Object? items) {
+                results.add(items! as List<CommandToRun>);
+                return true;
+              },
+            ),
+          ),
+          sequentially: true,
+          bail: false,
+          label: any(named: 'label'),
+          maxAttempts: any(named: 'maxAttempts'),
+          retryAfter: any(named: 'retryAfter'),
+        ),
+      ).called(2);
+
+      expect(results, expected);
+    });
   });
 }
 

--- a/packages/sip/test/e2e/run/concurrency_groups/concurrency_groups_test.dart
+++ b/packages/sip/test/e2e/run/concurrency_groups/concurrency_groups_test.dart
@@ -1,0 +1,172 @@
+// ignore_for_file: avoid_redundant_argument_values
+
+import 'dart:io' as io;
+
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:path/path.dart' as path;
+import 'package:sip_cli/commands/script_run_command.dart';
+import 'package:sip_cli/domain/bindings.dart';
+import 'package:sip_cli/domain/command_result.dart';
+import 'package:sip_cli/domain/command_to_run.dart';
+import 'package:sip_cli/domain/domain.dart';
+import 'package:sip_cli/domain/pubspec_yaml.dart';
+import 'package:sip_cli/domain/scripts_yaml.dart';
+import 'package:sip_cli/domain/variables.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('concurrency groups test', () {
+    late FileSystem fs;
+    late Bindings bindings;
+    late Logger logger;
+    late RunOneScript runOneScript;
+    late RunManyScripts runManyScripts;
+
+    setUpAll(() {
+      registerFallbackValue(
+        const CommandToRun(command: '__fake__', workingDirectory: '', keys: []),
+      );
+    });
+
+    setUp(() {
+      bindings = _MockBindings();
+      logger = _MockLogger();
+      final progress = _MockProgress();
+      when(() => logger.level).thenReturn(Level.quiet);
+      when(() => logger.progress(any())).thenReturn(progress);
+
+      runOneScript = _MockRunOneScript();
+      runManyScripts = _MockRunManyScript();
+
+      when(() => runManyScripts.runOneScript).thenReturn(runOneScript);
+      when(
+        () => runOneScript.run(
+          command: any(named: 'command'),
+          showOutput: any(named: 'showOutput'),
+          filter: any(named: 'filter'),
+          maxAttempts: any(named: 'maxAttempts'),
+          retryAfter: any(named: 'retryAfter'),
+        ),
+      ).thenAnswer(
+        (invocation) async => const CommandResult(
+          exitCode: 0,
+          output: '',
+          error: '',
+        ),
+      );
+      when(
+        () => runManyScripts.run(
+          commands: any(named: 'commands'),
+          sequentially: any(named: 'sequentially'),
+          bail: any(named: 'bail'),
+          label: any(named: 'label'),
+          maxAttempts: any(named: 'maxAttempts'),
+          retryAfter: any(named: 'retryAfter'),
+        ),
+      ).thenAnswer(
+        (invocation) async => [
+          if (invocation.namedArguments[#commands]
+              case final List<CommandToRun> commands)
+            for (final command in commands)
+              CommandResult(
+                exitCode: 0,
+                output: command.command,
+                error: '',
+              ),
+        ],
+      );
+
+      fs = MemoryFileSystem.test();
+
+      final cwd = fs.directory(path.join('packages', 'sip'))
+        ..createSync(recursive: true);
+      fs.currentDirectory = cwd;
+    });
+
+    test('runs gracefully', () async {
+      final input = io.File(
+        path.join(
+          'test',
+          'e2e',
+          'run',
+          'concurrency_groups',
+          'inputs',
+          'scripts.yaml',
+        ),
+      ).readAsStringSync();
+
+      fs.file(ScriptsYaml.fileName)
+        ..createSync(recursive: true)
+        ..writeAsStringSync(input);
+      fs.file(PubspecYaml.fileName)
+        ..createSync(recursive: true)
+        ..writeAsStringSync('');
+
+      final command = ScriptRunCommand(
+        bindings: bindings,
+        cwd: CWDImpl(fs: fs),
+        logger: logger,
+        scriptsYaml: ScriptsYamlImpl(fs: fs),
+        variables: Variables(
+          cwd: CWDImpl(fs: fs),
+          pubspecYaml: PubspecYamlImpl(fs: fs),
+          scriptsYaml: ScriptsYamlImpl(fs: fs),
+        ),
+        runManyScripts: runManyScripts,
+        runOneScript: runOneScript,
+      );
+
+      await command.run(['combined']);
+
+      verify(
+        () => runManyScripts.run(
+          commands: any(
+            named: 'commands',
+            that: isA<List<CommandToRun>>().having(
+              (items) {
+                return items;
+              },
+              'has correct scripts',
+              [
+                ...[
+                  'wait 1',
+                  'wait 2',
+                  'wait 3',
+                ].map(
+                  (e) => CommandToRun(
+                    command: e,
+                    workingDirectory: '/packages/sip',
+                    keys: const ['combined'],
+                    runPreviousFirst: true,
+                    bail: false,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          sequentially: true,
+          bail: false,
+          label: any(named: 'label'),
+          maxAttempts: any(named: 'maxAttempts'),
+          retryAfter: any(named: 'retryAfter'),
+        ),
+      ).called(1);
+
+      // verify calls to the multi and single script runners
+      expect(true, isFalse);
+    });
+  });
+}
+
+class _MockBindings extends Mock implements Bindings {}
+
+class _MockLogger extends Mock implements Logger {}
+
+class _MockProgress extends Mock implements Progress {}
+
+class _MockRunOneScript extends Mock implements RunOneScript {}
+
+class _MockRunManyScript extends Mock implements RunManyScripts {}

--- a/packages/sip/test/e2e/run/concurrency_groups/inputs/scripts.yaml
+++ b/packages/sip/test/e2e/run/concurrency_groups/inputs/scripts.yaml
@@ -1,0 +1,51 @@
+all_concurrent:
+  - "(+) wait 1"
+  - "(+) wait 2"
+  - "(+) wait 3"
+
+partial_concurrent:
+  - "(+) wait 4"
+  - "(+) wait 5"
+  - "echo 6"
+
+no_concurrent:
+  - "wait 1; echo 1"
+  - "wait 1; echo 2"
+  - "wait 1; echo 3"
+
+combined:
+  - "{$all_concurrent}"
+  - "{$partial_concurrent}"
+  - "{$no_concurrent}"
+
+combined_concurrent:
+  - "{$all_concurrent}"
+  - "(+) {$partial_concurrent}"
+  - "(+) {$no_concurrent}"
+
+_combined_expected:
+  # first group
+  - "(+) wait 1"
+  - "(+) wait 2"
+  - "(+) wait 3"
+  # wait till group 1 then run second group
+  - "(+) wait 4"
+  - "(+) wait 5"
+  - "echo 6"
+  # wait til group 2 then run third group
+  - "wait 1; echo 1"
+  - "wait 1; echo 2"
+  - "wait 1; echo 3"
+
+_combined_concurrent_expected:
+  # first group
+  - "(+) wait 1"
+  - "(+) wait 2"
+  - "(+) wait 3"
+  # wait till group 1 then run second group
+  - "(+) (+) wait 4"
+  - "(+) (+) wait 5"
+  - "(+) echo 6"
+  - "(+) wait 1; echo 1"
+  - "(+) wait 1; echo 2"
+  - "(+) wait 1; echo 3"

--- a/packages/sip/test/e2e/run/concurrency_groups/inputs/scripts.yaml
+++ b/packages/sip/test/e2e/run/concurrency_groups/inputs/scripts.yaml
@@ -21,6 +21,10 @@ combined:
 combined_concurrent:
   - "{$all_concurrent}"
   - "(+) {$partial_concurrent}"
+
+everything_concurrent:
+  - "(+) {$all_concurrent}"
+  - "(+) {$partial_concurrent}"
   - "(+) {$no_concurrent}"
 
 _combined_expected:

--- a/packages/sip/test/e2e/run/coverage/coverage_test.dart
+++ b/packages/sip/test/e2e/run/coverage/coverage_test.dart
@@ -15,15 +15,17 @@ import 'package:sip_cli/domain/scripts_yaml.dart';
 import 'package:sip_cli/domain/variables.dart';
 import 'package:test/test.dart';
 
+import '../../../utils/stub_logger.dart';
+
 void main() {
   group('env files e2e', () {
     late FileSystem fs;
-    late _MockBindings mockBindings;
-    late Logger mockLogger;
+    late _TestBindings bindings;
+    late Logger logger;
 
     setUp(() {
-      mockBindings = _MockBindings();
-      mockLogger = _MockLogger();
+      bindings = _TestBindings();
+      logger = _MockLogger()..stub();
 
       fs = MemoryFileSystem.test();
 
@@ -54,16 +56,27 @@ void main() {
           ..createSync(recursive: true)
           ..writeAsStringSync('');
 
+        final runOneScript = RunOneScript(
+          bindings: bindings,
+          logger: logger,
+        );
+
         final command = ScriptRunCommand(
-          bindings: mockBindings,
+          bindings: bindings,
           cwd: CWDImpl(fs: fs),
-          logger: mockLogger,
+          logger: logger,
           scriptsYaml: ScriptsYamlImpl(fs: fs),
           variables: Variables(
             cwd: CWDImpl(fs: fs),
             pubspecYaml: PubspecYamlImpl(fs: fs),
             scriptsYaml: ScriptsYamlImpl(fs: fs),
           ),
+          runManyScripts: RunManyScripts(
+            bindings: bindings,
+            logger: logger,
+            runOneScript: runOneScript,
+          ),
+          runOneScript: runOneScript,
         );
 
         return command;
@@ -79,7 +92,7 @@ void main() {
         await Future<void>.delayed(const Duration(milliseconds: 100));
 
         expect(
-          mockBindings.scripts,
+          bindings.scripts,
           [
             'cd /packages/sip || exit 1',
             '',
@@ -93,7 +106,7 @@ void main() {
         await command.run(['test', '--coverage']);
 
         expect(
-          mockBindings.scripts,
+          bindings.scripts,
           [
             'cd /packages/sip || exit 1',
             '',
@@ -107,7 +120,7 @@ void main() {
         await command.run(['test', '--coverage=banana']);
 
         expect(
-          mockBindings.scripts,
+          bindings.scripts,
           [
             'cd /packages/sip || exit 1',
             '',
@@ -121,7 +134,7 @@ void main() {
         await command.run(['test', '--coverage', 'monkey']);
 
         expect(
-          mockBindings.scripts,
+          bindings.scripts,
           [
             'cd /packages/sip || exit 1',
             '',
@@ -134,7 +147,7 @@ void main() {
   });
 }
 
-class _MockBindings implements Bindings {
+class _TestBindings implements Bindings {
   final List<String> scripts = [];
 
   @override
@@ -154,7 +167,4 @@ class _MockBindings implements Bindings {
   }
 }
 
-class _MockLogger extends Mock implements Logger {
-  @override
-  Level get level => Level.quiet;
-}
+class _MockLogger extends Mock implements Logger {}

--- a/packages/sip/test/e2e/run/env_files/env_files_test.dart
+++ b/packages/sip/test/e2e/run/env_files/env_files_test.dart
@@ -57,6 +57,11 @@ void main() {
           ..createSync(recursive: true)
           ..writeAsStringSync('');
 
+        final runOneScript = RunOneScript(
+          bindings: bindings,
+          logger: logger,
+        );
+
         final command = ScriptRunCommand(
           bindings: bindings,
           cwd: CWDImpl(fs: fs),
@@ -67,6 +72,12 @@ void main() {
             pubspecYaml: PubspecYamlImpl(fs: fs),
             scriptsYaml: ScriptsYamlImpl(fs: fs),
           ),
+          runManyScripts: RunManyScripts(
+            bindings: bindings,
+            logger: logger,
+            runOneScript: runOneScript,
+          ),
+          runOneScript: runOneScript,
         );
 
         return command;

--- a/packages/sip/test/e2e/test_command/test_command_test.dart
+++ b/packages/sip/test/e2e/test_command/test_command_test.dart
@@ -10,6 +10,8 @@ import 'package:sip_cli/domain/filter_type.dart';
 import 'package:sip_cli/domain/find_file.dart';
 import 'package:sip_cli/domain/pubspec_lock_impl.dart';
 import 'package:sip_cli/domain/pubspec_yaml_impl.dart';
+import 'package:sip_cli/domain/run_many_scripts.dart';
+import 'package:sip_cli/domain/run_one_script.dart';
 import 'package:sip_cli/domain/scripts_yaml_impl.dart';
 import 'package:test/test.dart';
 
@@ -29,6 +31,8 @@ void main() {
 
       fs = MemoryFileSystem.test();
 
+      final runOneScript = RunOneScript(bindings: bindings, logger: logger);
+
       command = TestRunCommand(
         pubspecYaml: PubspecYamlImpl(fs: fs),
         fs: fs,
@@ -37,6 +41,12 @@ void main() {
         pubspecLock: PubspecLockImpl(fs: fs),
         findFile: FindFile(fs: fs),
         scriptsYaml: ScriptsYamlImpl(fs: fs),
+        runManyScripts: RunManyScripts(
+          bindings: bindings,
+          logger: logger,
+          runOneScript: runOneScript,
+        ),
+        runOneScript: runOneScript,
       );
 
       final cwd = fs.directory(path.join('packages', 'sip'))

--- a/packages/sip/test/lib/commands/test_watch_command_test.dart
+++ b/packages/sip/test/lib/commands/test_watch_command_test.dart
@@ -8,6 +8,8 @@ import 'package:sip_cli/domain/find_file.dart';
 import 'package:sip_cli/domain/package_to_test.dart';
 import 'package:sip_cli/domain/pubspec_lock_impl.dart';
 import 'package:sip_cli/domain/pubspec_yaml_impl.dart';
+import 'package:sip_cli/domain/run_many_scripts.dart';
+import 'package:sip_cli/domain/run_one_script.dart';
 import 'package:sip_cli/domain/scripts_yaml_impl.dart';
 import 'package:sip_cli/utils/determine_flutter_or_dart.dart';
 import 'package:sip_cli/utils/key_press_listener.dart';
@@ -24,6 +26,11 @@ void main() {
 
       mockLogger = _MockLogger();
 
+      final runOneScript = RunOneScript(
+        bindings: _MockBindings(),
+        logger: mockLogger,
+      );
+
       testWatchCommand = TestWatchCommand(
         bindings: _MockBindings(),
         findFile: FindFile(fs: fs),
@@ -33,6 +40,12 @@ void main() {
         pubspecYaml: PubspecYamlImpl(fs: fs),
         keyPressListener: KeyPressListener(logger: mockLogger),
         scriptsYaml: ScriptsYamlImpl(fs: fs),
+        runManyScripts: RunManyScripts(
+          bindings: _MockBindings(),
+          logger: mockLogger,
+          runOneScript: runOneScript,
+        ),
+        runOneScript: runOneScript,
       );
     });
 

--- a/packages/sip/test/lib/commands/tester_mixin_test.dart
+++ b/packages/sip/test/lib/commands/tester_mixin_test.dart
@@ -30,6 +30,10 @@ void main() {
       mockLogger = _MockLogger();
 
       fs = MemoryFileSystem.test();
+      final runOneScript = RunOneScript(
+        bindings: mockBindings,
+        logger: mockLogger,
+      );
 
       tester = _Tester(
         bindings: mockBindings,
@@ -39,6 +43,12 @@ void main() {
         fs: fs,
         logger: mockLogger,
         scriptsYaml: ScriptsYamlImpl(fs: fs),
+        runManyScripts: RunManyScripts(
+          bindings: mockBindings,
+          logger: mockLogger,
+          runOneScript: runOneScript,
+        ),
+        runOneScript: runOneScript,
       );
     });
 
@@ -686,6 +696,8 @@ class _Tester extends TesterMixin {
     required this.pubspecLock,
     required this.pubspecYaml,
     required this.scriptsYaml,
+    required this.runManyScripts,
+    required this.runOneScript,
   });
   @override
   final Bindings bindings;
@@ -707,6 +719,12 @@ class _Tester extends TesterMixin {
 
   @override
   final PubspecYaml pubspecYaml;
+
+  @override
+  final RunManyScripts runManyScripts;
+
+  @override
+  final RunOneScript runOneScript;
 }
 
 class _MockBindings extends Mock implements Bindings {}

--- a/packages/sip/test/lib/utils/run_script_helper_test.dart
+++ b/packages/sip/test/lib/utils/run_script_helper_test.dart
@@ -564,6 +564,7 @@ cd packages/domain
               commands: {'pub env command'},
               files: {'some/path/to/test/.env'},
             ),
+            needsRunBeforeNext: true,
           );
 
           expect(result.commands?.elementAt(0), pubExpected);
@@ -578,6 +579,7 @@ cd packages/domain
               commands: {'other env command'},
               files: {'some/path/to/other/.env'},
             ),
+            needsRunBeforeNext: true,
           );
 
           expect(result.commands?.elementAt(1), otherExpected);
@@ -647,6 +649,7 @@ cd packages/domain
               commands: {'all env command', 'pub env command'},
               files: {'some/path/to/all/.env', 'some/path/to/test/.env'},
             ),
+            needsRunBeforeNext: true,
           );
 
           expect(result.commands?.elementAt(0), pubExpected);
@@ -661,6 +664,7 @@ cd packages/domain
               commands: {'all env command', 'other env command'},
               files: {'some/path/to/all/.env', 'some/path/to/other/.env'},
             ),
+            needsRunBeforeNext: true,
           );
 
           expect(result.commands?.elementAt(1), otherExpected);

--- a/packages/sip/test/utils/stub_logger.dart
+++ b/packages/sip/test/utils/stub_logger.dart
@@ -1,0 +1,14 @@
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+
+extension LoggerX on Logger {
+  void stub({
+    Level level = Level.quiet,
+  }) {
+    final instance = this;
+    when(() => instance.level).thenReturn(level);
+    when(() => instance.progress(any())).thenReturn(_MockProgress());
+  }
+}
+
+class _MockProgress extends Mock implements Progress {}

--- a/scripts.yaml
+++ b/scripts.yaml
@@ -9,8 +9,17 @@ _packages:
 
 pana: "{$_packages} dart pub run pana"
 
-format: "{$_packages} dart format ."
-analyze: "{$_packages} dart analyze ."
+format:
+  - "(+) {$_packages} dart format ."
+  - "(+) {$_packages} dart format ."
+  - "(+) {$_packages} dart format ."
+analyze: "(+) {$_packages} dart analyze ."
+
+some:
+  - "{$format}"
+  - "echo ''"
+  - "{$analyze}"
+  - "sip run test"
 
 barrel: cd packages/sip && dart run barreler build
 


### PR DESCRIPTION
Before this PR, commands grouped concurrency by referring only to their sibling commands. With this change, commands now also reference the original command, ensuring concurrency is scoped to all referenced commands.

This PR also introduces the CTRL+C back and will exit completely regardless of the process's state.