### PR TITLE
fix: resolve hang when all concurrent tasks complete out of order

### DIFF
--- a/lib/src/domain/script_runner.dart
+++ b/lib/src/domain/script_runner.dart
@@ -269,6 +269,12 @@ class ScriptRunner {
       done = logger.progress('${cyan.wrap(output)}');
     }
 
+    // Tracks whether the for-loop has finished launching all tasks.
+    // Parallel `.then()` callbacks are microtasks — they cannot fire until
+    // the synchronous loop body completes, so reading this flag inside a
+    // callback is safe.
+    var allLaunched = false;
+
     for (final (index, (part, future)) in pending.indexed) {
       if (printLabels) {
         if (part case ScriptToRun(:final String label)) {
@@ -311,7 +317,7 @@ class ScriptRunner {
           if (running.isEmpty) {
             waitForRunning?.complete();
 
-            if (index == pending.length - 1) {
+            if (allLaunched) {
               controller.close().ignore();
             }
           }
@@ -330,6 +336,15 @@ class ScriptRunner {
           controller.close().ignore();
         }
       }
+    }
+
+    allLaunched = true;
+
+    // If all tasks were parallel and all completed during an earlier `await`
+    // (e.g. mixed parallel + sequential groups), the controller may still be
+    // open. Close it now.
+    if (running.isEmpty && !controller.isClosed) {
+      controller.close().ignore();
     }
 
     if (waitForRunning case final completer?) {


### PR DESCRIPTION
## Problem

When running commands like `sip pub get -r` (recursive, concurrent), the process hangs indefinitely after all tasks complete. All 14 packages resolve successfully and the progress spinner shows a checkmark, but the process never exits.

## Root Cause

In `ScriptRunner._group()`, the `StreamController` is only closed when the task at the **last index** (`pending.length - 1`) finishes AND `running.isEmpty`. But tasks complete in arbitrary order — if the last-launched task isn't the last to **finish**, the controller is never closed and `yield* controller.stream` blocks forever.

```dart
// Before: only closes if the specific last-indexed task finishes last
if (running.isEmpty) {
  waitForRunning?.complete();
  if (index == pending.length - 1) {  // ← bug: index is launch order, not completion order
    controller.close().ignore();
  }
}
```

## Fix

Replace the index check with an `allLaunched` flag set after the for-loop finishes launching all tasks. Since `.then()` callbacks are microtasks, they cannot fire until the synchronous loop body completes, making the flag safe to read inside callbacks.

Also adds a post-loop safety net for the edge case where all parallel tasks complete during an earlier `await` (mixed parallel + sequential groups).

## Testing

- All 165 existing tests pass (1 pre-existing skip)
- Verified locally: `sip pub get -r` (concurrent) against a monorepo with 14 packages — previously hung indefinitely, now exits cleanly
- `sip pub get -r --no-concurrent` continues to work as before